### PR TITLE
Support page specific install

### DIFF
--- a/db.js
+++ b/db.js
@@ -101,6 +101,42 @@ const Document = sequelize.define('document', {
   },
 });
 
+const Page = sequelize.define('page', {
+  id: {
+    type: Sequelize.BIGINT,
+    primaryKey: true,
+  },
+  name: {
+    type: Sequelize.STRING,
+    validate: {
+      notEmpty: true,
+    },
+    allowNull: false,
+  },
+  accessToken: {
+    type: Sequelize.STRING(510),
+    validate: {
+      notEmpty: true,
+    },
+    allowNull: false,
+  },
+  communityId: {
+    type: Sequelize.BIGINT,
+    allowNull: false,
+  },
+  communityName: {
+    type: Sequelize.STRING,
+    validate: {
+      notEmpty: true,
+    },
+    allowNull: false,
+  },
+  installId: {
+    type: Sequelize.BIGINT,
+    allowNull: false,
+  },
+});
+
 const Community = sequelize.define('community', {
   id: {
     type: Sequelize.BIGINT,
@@ -151,7 +187,7 @@ let force = process.env.DROP_TABLES && process.env.DROP_TABLES.toLowerCase() ===
 let sync = process.env.SYNC_TABLES && process.env.SYNC_TABLES.toLowerCase() === 'true';
 
 if (sync || force) {
-  Promise.all([Community.sync({force}), Callback.sync({force})])
+  Promise.all([Community.sync({force}), Callback.sync({force}), Page.sync({force})])
     .then(() => User.sync({force}))
     .then(() => Folder.sync({force}))
     .then(() => Promise.all([Document.sync({force}), Task.sync({force})]))

--- a/routes/loggedout.js
+++ b/routes/loggedout.js
@@ -111,25 +111,27 @@ router.route('/community_install')
         code: req.query.code,
       })
       .send()
-      .then(tokenResponse => graph('community')
-        .token(tokenResponse.access_token)
-        .qs({ fields: 'name' })
-        .send()
-        .then(communityResponse => db.models.community
-          .findById(communityResponse.id)
-          .then(community => {
-            if (community) {
-              return community.update({accessToken: tokenResponse.access_token});
-            } else {
-              return db.models.community.create({
-                id: communityResponse.id,
-                name: communityResponse.name,
-                accessToken: tokenResponse.access_token,
-              });
-            }
-          })
-        )
-      )
+      .then(tokenResponse => {
+        console.log(tokenResponse);
+        return graph('community')
+          .token(tokenResponse.access_token)
+          .qs({ fields: 'name' })
+          .send()
+          .then(communityResponse => db.models.community
+            .findById(communityResponse.id)
+            .then(community => {
+              if (community) {
+                return community.update({accessToken: tokenResponse.access_token});
+              } else {
+                return db.models.community.create({
+                  id: communityResponse.id,
+                  name: communityResponse.name,
+                  accessToken: tokenResponse.access_token,
+                });
+              }
+            })
+          );
+      })
       .then(community => {
         const redirect = req.query.redirect_uri;
         const state = req.query.state;

--- a/static/js/pageInstallSuccess.js
+++ b/static/js/pageInstallSuccess.js
@@ -1,0 +1,3 @@
+setTimeout(function(){
+    self.close();
+},3000);

--- a/views/admin.pug
+++ b/views/admin.pug
@@ -4,6 +4,25 @@ block content
   h2 Admin Panel
   p.
     Various information about the current status of the application.
+
+  h2 Workplace Install (with full perms)
+  button(type="button", onclick="window.open('https://work.mengk.sb.facebook.com/v3.2/dialog/work/app_install?app_id=329713124440482&redirect_uri=https%3A%2F%2Fscott-taaskly.herokuapp.com%2Fcommunity_install%0D%0A','wp','width=800,height=1000');") Install
+
+  h2 Workplace Install (with selected perms)
+  form(action="https://work.mengk.sb.facebook.com/v3.2/dialog/work/app_install" method="get" onsubmit="window.open('', 'wp', 'width=800,height=1000'); this.target = 'wp';")
+    input.form-control(type="hidden", name="app_id", value=329713124440482)
+    input.form-control(type="hidden", name="redirect_uri", value="https://scott-taaskly.herokuapp.com/page_install")
+    div.form-group
+      p Choose permissions required:
+        each val in ["link_unfurling", "bot_mention", "message", "read_user_email"]
+          div.checkbox-inline
+            input.checkbox-input(type='checkbox', name=`permissions[]`, value=val, id=`perm_${val}`)
+            label(for=`perm_${val}`)=val
+    div.form-group
+      label(for='suggested_page_name') Bot name:
+      input.form-control(type='text' id='suggested_page_name' placeholder='Bot name' name='suggested_page_name')
+    button(type="submit") Install
+
   h2 Webhook Subscriptions
   form(action="/admin/subscribe" method="post")
     button(type="submit") Subscribe

--- a/views/admin.pug
+++ b/views/admin.pug
@@ -23,6 +23,20 @@ block content
       input.form-control(type='text' id='suggested_page_name' placeholder='Bot name' name='suggested_page_name')
     button(type="submit") Install
 
+  h2 Workplace Install Upgrade
+  form(action="https://work.mengk.sb.facebook.com/v3.2/dialog/work/app_upgrade" method="get" onsubmit="window.open('', 'wp', 'width=800,height=1000'); this.target = 'wp';")
+    input.form-control(type="hidden", name="redirect_uri", value="https://scott-taaskly.herokuapp.com/page_install")
+    div.form-group
+      p Choose permissions required:
+        each val in ["link_unfurling", "bot_mention", "message", "read_user_email"]
+          div.checkbox-inline
+            input.checkbox-input(type='checkbox', name=`permissions[]`, value=val, id=`perm_${val}`)
+            label(for=`perm_${val}`)=val
+    div.form-group
+      label(for='install_id') Intall ID:
+      input.form-control(type='text' id='install_id' placeholder='123' name='install_id')
+    button(type="submit") Install
+
   h2 Webhook Subscriptions
   form(action="/admin/subscribe" method="post")
     button(type="submit") Subscribe

--- a/views/admin.pug
+++ b/views/admin.pug
@@ -6,7 +6,7 @@ block content
     Various information about the current status of the application.
 
   h2 Workplace Install (with full perms)
-  button(type="button", onclick="window.open('https://work.mengk.sb.facebook.com/v3.2/dialog/work/app_install?app_id=329713124440482&redirect_uri=https%3A%2F%2Fscott-taaskly.herokuapp.com%2Fcommunity_install%0D%0A','wp','width=800,height=1000');") Install
+  button(type="button", onclick="window.open('https://www.workplace.com/v3.2/dialog/work/app_install?app_id=329713124440482&redirect_uri=https%3A%2F%2Fscott-taaskly.herokuapp.com%2Fcommunity_install%0D%0A','wp','width=800,height=1000');") Install
 
   h2 Workplace Install (with selected perms)
   form(action="https://work.mengk.sb.facebook.com/v3.2/dialog/work/app_install" method="get" onsubmit="window.open('', 'wp', 'width=800,height=1000'); this.target = 'wp';")

--- a/views/admin.pug
+++ b/views/admin.pug
@@ -6,10 +6,10 @@ block content
     Various information about the current status of the application.
 
   h2 Workplace Install (with full perms)
-  button(type="button", onclick="window.open('https://www.workplace.com/v3.2/dialog/work/app_install?app_id=329713124440482&redirect_uri=https%3A%2F%2Fscott-taaskly.herokuapp.com%2Fcommunity_install%0D%0A','wp','width=800,height=1000');") Install
+  button(type="button", onclick="window.open('https://work.facebook.com/v3.2/dialog/work/app_install?app_id=329713124440482&redirect_uri=https%3A%2F%2Fscott-taaskly.herokuapp.com%2Fcommunity_install%0D%0A','wp','width=800,height=1000');") Install
 
   h2 Workplace Install (with selected perms)
-  form(action="https://work.mengk.sb.facebook.com/v3.2/dialog/work/app_install" method="get" onsubmit="window.open('', 'wp', 'width=800,height=1000'); this.target = 'wp';")
+  form(action="https://work.facebook.com/v3.2/dialog/work/app_install" method="get" onsubmit="window.open('', 'wp', 'width=800,height=1000'); this.target = 'wp';")
     input.form-control(type="hidden", name="app_id", value=329713124440482)
     input.form-control(type="hidden", name="redirect_uri", value="https://scott-taaskly.herokuapp.com/page_install")
     div.form-group

--- a/views/pageInstallSuccess.pug
+++ b/views/pageInstallSuccess.pug
@@ -1,0 +1,15 @@
+extends layout
+    
+block navigation
+
+block content
+  script(src='/js/pageInstallSuccess.js')
+  h1 Community Installed
+  p.
+    Taaskly has been successfuly installed on the community #[strong= page.communityName] as #[strong = page.name].
+  if state
+    p The following state param has been passed:
+    pre= state
+  else
+    p No state param has been passed.
+  p This window will close in 3 seconds.    


### PR DESCRIPTION
Change list:

- Add dedicated table to store page-specific tokens
- Enable install to succeed for PageInstall
- Add simple messaging handling logic to prove that bots can be self-aware